### PR TITLE
Fix PDF viewer blank page rendering

### DIFF
--- a/pdf_editor.py
+++ b/pdf_editor.py
@@ -177,9 +177,12 @@ class PDFEditor(QMainWindow):
         try:
             page = self.doc[self.current_page]
             pix = page.get_pixmap()
-            img = QImage(
-                pix.samples, pix.width, pix.height, pix.stride, QImage.Format_RGBA8888
+            image_format = (
+                QImage.Format_RGBA8888 if pix.n >= 4 else QImage.Format_RGB888
             )
+            img = QImage(pix.samples, pix.width, pix.height, pix.stride, image_format)
+            if image_format == QImage.Format_RGB888:
+                img = img.rgbSwapped()
             pixmap = QPixmap.fromImage(img)
             self.scene.clear()
             self.scene.setSceneRect(0, 0, pix.width, pix.height)


### PR DESCRIPTION
## Summary
- Detect pixmap color format and choose matching `QImage` format
- Swap RGB channels when required before converting to `QPixmap`

## Testing
- `python -m py_compile pdf_editor.py`


------
https://chatgpt.com/codex/tasks/task_b_689af0d341fc832ca65728f34f5faafc