### PR TITLE
Add undo, zoom, and text box tools

### DIFF
--- a/pdf_editor.py
+++ b/pdf_editor.py
@@ -11,8 +11,9 @@ from PyQt5.QtWidgets import (
     QGraphicsScene,
     QAction,
     QToolBar,
+    QInputDialog,
 )
-from PyQt5.QtGui import QImage, QPixmap, QPen
+from PyQt5.QtGui import QImage, QPixmap, QPen, QBrush
 from PyQt5.QtCore import Qt, QPointF, QRectF
 
 
@@ -53,9 +54,12 @@ class PDFGraphicsView(QGraphicsView):
                 self._temp_item = self.scene().addLine(
                     self._start.x(), self._start.y(), end.x(), end.y(), pen
                 )
-            elif tool == "rect":
+            elif tool in {"rect", "text", "text_fill"}:
                 rect = QRectF(self._start, end).normalized()
-                self._temp_item = self.scene().addRect(rect, pen)
+                if tool == "text_fill":
+                    self._temp_item = self.scene().addRect(rect, pen, QBrush(Qt.yellow))
+                else:
+                    self._temp_item = self.scene().addRect(rect, pen)
             elif tool == "ellipse":
                 rect = QRectF(self._start, end).normalized()
                 self._temp_item = self.scene().addEllipse(rect, pen)
@@ -75,13 +79,16 @@ class PDFGraphicsView(QGraphicsView):
                 self._parent.add_shape(
                     "line", (self._start.x(), self._start.y(), end.x(), end.y())
                 )
-            elif tool == "rect":
+            elif tool in {"rect", "text", "text_fill"}:
                 rect = QRectF(self._start, end).normalized()
-                self.scene().addRect(rect, pen)
-                self._parent.add_shape(
-                    "rect",
-                    (rect.left(), rect.top(), rect.right(), rect.bottom()),
-                )
+                if tool == "rect":
+                    self.scene().addRect(rect, pen)
+                    self._parent.add_shape(
+                        "rect",
+                        (rect.left(), rect.top(), rect.right(), rect.bottom()),
+                    )
+                else:
+                    self._parent.add_text_box(rect, fill=(tool == "text_fill"))
             elif tool == "ellipse":
                 rect = QRectF(self._start, end).normalized()
                 self.scene().addEllipse(rect, pen)
@@ -102,11 +109,13 @@ class PDFEditor(QMainWindow):
         self.doc = None
         self.current_page = 0
         self.current_tool = None
+        self.zoom = 1.0
         self.shapes = defaultdict(list)  # page number -> list of shapes
 
         self.scene = QGraphicsScene()
         self.view = PDFGraphicsView(self.scene, self)
         self.setCentralWidget(self.view)
+        self.view.setTransformationAnchor(QGraphicsView.AnchorUnderMouse)
 
         self._create_actions()
         logger.debug("PDFEditor initialized")
@@ -128,13 +137,33 @@ class PDFEditor(QMainWindow):
         next_act.triggered.connect(self.next_page)
 
         line_act = QAction("Line", self, checkable=True)
+        line_act.setData("line")
         line_act.triggered.connect(lambda: self.set_tool("line"))
 
         rect_act = QAction("Rectangle", self, checkable=True)
+        rect_act.setData("rect")
         rect_act.triggered.connect(lambda: self.set_tool("rect"))
 
         ell_act = QAction("Ellipse", self, checkable=True)
+        ell_act.setData("ellipse")
         ell_act.triggered.connect(lambda: self.set_tool("ellipse"))
+
+        text_act = QAction("Text", self, checkable=True)
+        text_act.setData("text")
+        text_act.triggered.connect(lambda: self.set_tool("text"))
+
+        text_fill_act = QAction("TextFill", self, checkable=True)
+        text_fill_act.setData("text_fill")
+        text_fill_act.triggered.connect(lambda: self.set_tool("text_fill"))
+
+        undo_act = QAction("Undo", self)
+        undo_act.triggered.connect(self.undo_last)
+
+        zoom_in_act = QAction("Zoom In", self)
+        zoom_in_act.triggered.connect(self.zoom_in)
+
+        zoom_out_act = QAction("Zoom Out", self)
+        zoom_out_act.triggered.connect(self.zoom_out)
 
         toolbar = QToolBar()
         toolbar.addAction(open_act)
@@ -144,14 +173,19 @@ class PDFEditor(QMainWindow):
         toolbar.addAction(line_act)
         toolbar.addAction(rect_act)
         toolbar.addAction(ell_act)
+        toolbar.addAction(text_act)
+        toolbar.addAction(text_fill_act)
+        toolbar.addAction(undo_act)
+        toolbar.addAction(zoom_in_act)
+        toolbar.addAction(zoom_out_act)
         self.addToolBar(toolbar)
 
-        self.tool_actions = [line_act, rect_act, ell_act]
+        self.tool_actions = [line_act, rect_act, ell_act, text_act, text_fill_act]
 
     def set_tool(self, name):
         self.current_tool = name
         for action in self.tool_actions:
-            action.setChecked(action.text().lower() == name)
+            action.setChecked(action.data() == name)
         logger.debug("Tool set to %s", name)
 
     # ------------------------------------------------------------------
@@ -165,6 +199,7 @@ class PDFEditor(QMainWindow):
         try:
             self.doc = fitz.open(path)
             self.current_page = 0
+            self.zoom = 1.0
             logger.info("Opened PDF '%s' with %d pages", path, self.doc.page_count)
             self.load_page()
         except Exception:
@@ -206,7 +241,25 @@ class PDFEditor(QMainWindow):
                 x1, y1, x2, y2 = data
                 rect = QRectF(x1, y1, x2 - x1, y2 - y1)
                 self.scene.addEllipse(rect, pen)
+            elif typ == "text":
+                x1, y1, x2, y2, text = data
+                rect = QRectF(x1, y1, x2 - x1, y2 - y1)
+                self.scene.addRect(rect, pen)
+                text_item = self.scene.addText(text)
+                text_item.setDefaultTextColor(Qt.black)
+                text_item.setPos(rect.topLeft())
+                text_item.setTextWidth(rect.width())
+            elif typ == "text_fill":
+                x1, y1, x2, y2, text = data
+                rect = QRectF(x1, y1, x2 - x1, y2 - y1)
+                self.scene.addRect(rect, pen, QBrush(Qt.yellow))
+                text_item = self.scene.addText(text)
+                text_item.setDefaultTextColor(Qt.black)
+                text_item.setPos(rect.topLeft())
+                text_item.setTextWidth(rect.width())
 
+        self.view.resetTransform()
+        self.view.scale(self.zoom, self.zoom)
         self.setWindowTitle(f"PDF Editor - Page {self.current_page + 1}/{self.doc.page_count}")
 
     def add_shape(self, typ, data):
@@ -217,6 +270,52 @@ class PDFEditor(QMainWindow):
             data,
             self.current_page + 1,
         )
+
+    def add_text_box(self, rect, fill=False):
+        text, ok = QInputDialog.getText(self, "Text", "Enter text:")
+        if not ok:
+            logger.info("Text box cancelled")
+            return
+        pen = QPen(Qt.red, 2)
+        brush = QBrush(Qt.yellow) if fill else QBrush(Qt.transparent)
+        self.scene.addRect(rect, pen, brush)
+        text_item = self.scene.addText(text)
+        text_item.setDefaultTextColor(Qt.black)
+        text_item.setPos(rect.topLeft())
+        text_item.setTextWidth(rect.width())
+        self.add_shape(
+            "text_fill" if fill else "text",
+            (rect.left(), rect.top(), rect.right(), rect.bottom(), text),
+        )
+        logger.debug(
+            "Added text box with fill=%s and text '%s' on page %d",
+            fill,
+            text,
+            self.current_page + 1,
+        )
+
+    def undo_last(self):
+        shapes = self.shapes[self.current_page]
+        if shapes:
+            removed = shapes.pop()
+            logger.debug(
+                "Undo shape %s on page %d", removed[0], self.current_page + 1
+            )
+            self.load_page()
+        else:
+            logger.info(
+                "Undo requested but no shapes on page %d", self.current_page + 1
+            )
+
+    def zoom_in(self):
+        self.zoom *= 1.25
+        self.view.scale(1.25, 1.25)
+        logger.debug("Zoomed in to %f", self.zoom)
+
+    def zoom_out(self):
+        self.zoom *= 0.8
+        self.view.scale(0.8, 0.8)
+        logger.debug("Zoomed out to %f", self.zoom)
 
     def next_page(self):
         if self.doc and self.current_page + 1 < self.doc.page_count:
@@ -255,6 +354,29 @@ class PDFEditor(QMainWindow):
                     elif typ == "ellipse":
                         x1, y1, x2, y2 = data
                         page.draw_oval([x1, y1, x2, y2], color=(1, 0, 0), width=2)
+                    elif typ == "text":
+                        x1, y1, x2, y2, text = data
+                        page.draw_rect([x1, y1, x2, y2], color=(1, 0, 0), width=2)
+                        page.insert_textbox(
+                            fitz.Rect(x1, y1, x2, y2),
+                            text,
+                            fontsize=12,
+                            color=(0, 0, 0),
+                        )
+                    elif typ == "text_fill":
+                        x1, y1, x2, y2, text = data
+                        page.draw_rect(
+                            [x1, y1, x2, y2],
+                            color=(1, 0, 0),
+                            width=2,
+                            fill=(1, 1, 0),
+                        )
+                        page.insert_textbox(
+                            fitz.Rect(x1, y1, x2, y2),
+                            text,
+                            fontsize=12,
+                            color=(0, 0, 0),
+                        )
             self.doc.save(path)
             logger.info("Saved PDF as %s", path)
         except Exception:


### PR DESCRIPTION
## Summary
- add undo toolbar button to remove last drawn shape
- implement zoom in/out controls that scale the current page view
- support text boxes with optional fill including saving to PDF

## Testing
- `python -m py_compile pdf_editor.py`


------
https://chatgpt.com/codex/tasks/task_b_689af35dc2ac832caa226077b63eb7c7